### PR TITLE
fix: the "LoginNoViewstate" error when login

### DIFF
--- a/BeanfunLogin/BeanfunClient.cs
+++ b/BeanfunLogin/BeanfunClient.cs
@@ -34,6 +34,14 @@ namespace BeanfunLogin
             { this.sacc = sacc; this.sotp = sotp; this.sname = sname; this.screatetime = screatetime; }
         }
 
+        static BeanfunClient()
+        {
+            // 原本預設的協定為 SSL3.0 + TLS1.0
+            // 由於Beanfun現在(2019/09/19)要求需要使用TLS1.2以上才能進入
+            // 在此將協定設定為 SSL3.0 + TLS1.2
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls12;
+        }
+
         public BeanfunClient()
         {
             this.redirect = true;

--- a/BeanfunLogin/BeanfunClient.cs
+++ b/BeanfunLogin/BeanfunClient.cs
@@ -36,9 +36,9 @@ namespace BeanfunLogin
 
         static BeanfunClient()
         {
-            // 原本預設的協定為 SSL3.0 + TLS1.0
-            // 由於Beanfun現在(2019/09/19)要求需要使用TLS1.2以上才能進入
-            // 在此將協定設定為 SSL3.0 + TLS1.2
+            // Default value of SecurityProtocol are SSL3.0 and TLS1.0
+            // Beanfun requires TLS1.2 after Sep 19 2019
+            // Set SecurityProtocol to SSL3.0 and TLS1.2
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls12;
         }
 


### PR DESCRIPTION
現在使用TLS1.1以下的安全協定會被導向至其他頁面而無法取得skey

新增:
    於BeanfunClient.cs內新增static建構式(將安全協定更改為TLS1.2的版本)

issue:#63